### PR TITLE
Add number formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm i @plcmp/pl-table
     <pl-table-column header="Name" field="name" sortable tooltip-field></pl-table-column>
     <pl-table-column header="Email" field="email" tooltip-field></pl-table-column>
     <pl-table-column header="Created" field="createdAt" kind="date" format="DD.MM.YYYY"></pl-table-column>
+    <pl-table-column header="Balance" field="balance" kind="number" format="+0,0#"></pl-table-column>
 </pl-table>
 
 <script type="module">
@@ -22,8 +23,8 @@ npm i @plcmp/pl-table
 
     const table = document.querySelector('#usersTable');
     table.data = [
-        { name: 'Alice', email: 'alice@example.com', createdAt: '2026-02-15' },
-        { name: 'Bob', email: 'bob@example.com', createdAt: '2026-02-16' }
+        { name: 'Alice', email: 'alice@example.com', createdAt: '2026-02-15', balance: 1234.5 },
+        { name: 'Bob', email: 'bob@example.com', createdAt: '2026-02-16', balance: -12.34 }
     ];
 </script>
 ```
@@ -76,8 +77,8 @@ Main public properties:
 - `header: string` - header label
 - `field: string` - row field path (supports dot notation)
 - `tooltipField: string` - tooltip field path for cell hover; when `tooltip-field` is present without a value, column `field` is used
-- `kind: string` - value kind (`date` supported)
-- `format: string` - date format when `kind="date"`
+- `kind: string` - value kind (`date` or `number`)
+- `format: string` - date format when `kind="date"`, number format mask when `kind="number"`
 - `width: number` - column width in pixels
 - `minWidth: number` - minimum width (default: `50`)
 - `align: string` - body alignment (`left` by default)
@@ -140,6 +141,14 @@ Use this for rich content or custom formatting.
 - Return empty text for cells that should not show hints.
 - Use `keep-hover` only when tooltip content is interactive.
 - Keep cell content and tooltip content aligned to avoid user confusion.
+
+## Number formatting
+
+Set `kind="number"` to format numeric values with `Intl.NumberFormat` using the `ru-RU` locale.
+
+Use `0` for required fraction digits and `#` for optional fraction digits. A leading `+` displays a sign for positive values except zero.
+
+Invalid or omitted formats use one required fraction digit by default.
 
 ## Sorting behavior
 

--- a/pl-table-column.js
+++ b/pl-table-column.js
@@ -4,9 +4,32 @@ import '@plcmp/pl-iconset-default';
 import dayjs from 'dayjs/esm/index.js';
 import { createTooltip } from '@plcmp/pl-tooltip';
 
+function getNumberFormatOptions(format) {
+    const match = format?.match(/^(?<signed>\+)?0(?:[,.](?=[0#])(?<required>0*)(?<optional>#*))?$/);
+
+    if (!match) return {
+        useGrouping: true,
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+        signDisplay: 'auto'
+    };
+
+    const { signed, required = '', optional = '' } = match.groups;
+
+    return {
+        useGrouping: true,
+        minimumFractionDigits: required.length,
+        maximumFractionDigits: required.length + optional.length,
+        signDisplay: signed ? 'exceptZero' : 'auto'
+    };
+}
+
 class PlTableColumn extends PlElement {
     /** @type ?PlTooltip */
     _tooltip;
+
+    /** @type {Intl.NumberFormat | undefined} */
+    _numberFormatter;
 
     static properties = {
         header: { type: String },
@@ -229,6 +252,14 @@ class PlTableColumn extends PlElement {
             if (kind === 'date' && row[field]) {
                 return dayjs(this.getByPath(row, field)).format(format || 'DD.MM.YYYY');
             }
+
+            if (kind === 'number') {
+                const value = this.getByPath(row, field);
+                if (!Number.isFinite(value)) return '';
+                this._numberFormatter ??= new Intl.NumberFormat('ru-RU', getNumberFormatOptions(format));
+                return this._numberFormatter.format(value);
+            }
+
             return this.getByPath(row, field);
         }
     }

--- a/pl-table.js
+++ b/pl-table.js
@@ -12,7 +12,30 @@ import dayjs from 'dayjs/esm/index.js';
 
 import './pl-table-column.js';
 
+function getNumberFormatOptions(format) {
+    const match = format?.match(/^(?<signed>\+)?0(?:[,.](?=[0#])(?<required>0*)(?<optional>#*))?$/);
+
+    if (!match) return {
+        useGrouping: true,
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+        signDisplay: 'auto'
+    };
+
+    const { signed, required = '', optional = '' } = match.groups;
+
+    return {
+        useGrouping: true,
+        minimumFractionDigits: required.length,
+        maximumFractionDigits: required.length + optional.length,
+        signDisplay: signed ? 'exceptZero' : 'auto'
+    };
+}
+
 class PlTable extends PlResizeableMixin(PlElement) {
+    /** @type {Intl.NumberFormat | undefined} */
+    _numberFormatter;
+
     static properties = {
         data: { type: Array, value: () => [], observer: '_dataObserver' },
         selected: { type: Object, value: null, observer: '_selectedObserver' },
@@ -570,6 +593,14 @@ class PlTable extends PlResizeableMixin(PlElement) {
             if (kind === 'date' && row[field]) {
                 return dayjs(this.getByPath(row, field)).format(format || 'DD.MM.YYYY');
             }
+
+            if (kind === 'number') {
+                const value = this.getByPath(row, field);
+                if (!Number.isFinite(value)) return '';
+                this._numberFormatter ??= new Intl.NumberFormat('ru-RU', getNumberFormatOptions(format));
+                return this._numberFormatter.format(value);
+            }
+
             return this.getByPath(row, field);
         }
     }


### PR DESCRIPTION
Добавлено форматирование значений числовых колонок через `kind="number"`.

Поддерживаются простые маски вида: `0`, `0,00`, `0,00###`, `+0,00##`.